### PR TITLE
Feat/spotify post

### DIFF
--- a/src/main/java/TeamRhymix/Rhymix/config/SecurityConfig.java
+++ b/src/main/java/TeamRhymix/Rhymix/config/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/css/**", "/js/**", "/image/**", "/favicon.ico").permitAll()
-                        .requestMatchers("/", "/info", "/join/**", "/find-id", "/find-password", "/api/users/**", "/api/posts/**").permitAll()
+                        .requestMatchers("/", "/info", "/join/**", "/find-id", "/find-password").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form
@@ -43,7 +43,6 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .invalidSessionUrl("/login")
                 )
-                .userDetailsService(customUserDetailsService)
                 .build();
     }
 

--- a/src/main/java/TeamRhymix/Rhymix/controller/post/PostController.java
+++ b/src/main/java/TeamRhymix/Rhymix/controller/post/PostController.java
@@ -15,6 +15,7 @@ import TeamRhymix.Rhymix.dto.PostResponseDto;
 
 import TeamRhymix.Rhymix.service.TrackService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,6 +25,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/posts")
 @RequiredArgsConstructor
@@ -43,10 +45,12 @@ public class PostController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         if (userDetails == null) {
+            log.warn("[POST] 인증 실패 - userDetails is null");
             return ResponseEntity.status(401).build();
         }
 
         String userId = userDetails.getUsername();
+        log.debug("[POST] 인증된 사용자 ID: {}", userId);
 
         // 트랙 먼저 저장
         Track track = trackService.findOrSaveTrack(request.getTrackId());

--- a/src/main/java/TeamRhymix/Rhymix/controller/post/PostController.java
+++ b/src/main/java/TeamRhymix/Rhymix/controller/post/PostController.java
@@ -5,6 +5,7 @@ import TeamRhymix.Rhymix.domain.Chat;
 import TeamRhymix.Rhymix.domain.Post;
 import TeamRhymix.Rhymix.dto.PostDto;
 import TeamRhymix.Rhymix.mapper.PostMapper;
+import TeamRhymix.Rhymix.security.CustomUserDetails;
 import TeamRhymix.Rhymix.service.PostService;
 
 import TeamRhymix.Rhymix.domain.Track;
@@ -24,7 +25,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
-@RequestMapping("api/posts")
+@RequestMapping("/api/posts")
 @RequiredArgsConstructor
 public class PostController {
 
@@ -39,7 +40,7 @@ public class PostController {
     @PostMapping
     public ResponseEntity<PostResponseDto> createPost(
             @RequestBody PostRequestDto request,
-            @AuthenticationPrincipal User userDetails
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         if (userDetails == null) {
             return ResponseEntity.status(401).build();

--- a/src/main/java/TeamRhymix/Rhymix/controller/post/PostController.java
+++ b/src/main/java/TeamRhymix/Rhymix/controller/post/PostController.java
@@ -57,6 +57,9 @@ public class PostController {
                 .postId(saved.getId())
                 .trackTitle(track.getTitle())
                 .trackArtist(track.getArtist())
+                .album(track.getAlbum())
+                .coverImage(track.getCoverImage())
+                .duration(track.getDuration())
                 .mood(request.getMood())
                 .weather(request.getWeather())
                 .comment(request.getComment())
@@ -67,7 +70,7 @@ public class PostController {
 
 
     @GetMapping("/today")
-    public ResponseEntity<PostDto> getTodayPost(
+    public ResponseEntity<PostResponseDto> getTodayPost(
             @RequestParam(required = false) String nickname,
             @AuthenticationPrincipal org.springframework.security.core.userdetails.User userDetails
     ) {
@@ -75,15 +78,29 @@ public class PostController {
             if (userDetails == null) {
                 return ResponseEntity.status(401).build();
             }
-            nickname = userDetails.getUsername(); // 본인 닉네임
+            nickname = userDetails.getUsername();
         }
 
         Post post = postService.getTodayPost(nickname);
+        if (post == null) return ResponseEntity.notFound().build();
 
-        return post != null
-                ? ResponseEntity.ok(postMapper.toDto(post))
-                : ResponseEntity.notFound().build();
+        Track track = trackService.findByTrackId(post.getTrackId());
+
+        PostResponseDto response = PostResponseDto.builder()
+                .postId(post.getId())
+                .trackTitle(track.getTitle())
+                .trackArtist(track.getArtist())
+                .album(track.getAlbum())
+                .coverImage(track.getCoverImage())
+                .duration(track.getDuration())
+                .mood(post.getMood())
+                .weather(post.getWeather())
+                .comment(post.getComment())
+                .build();
+
+        return ResponseEntity.ok(response);
     }
+
 
 
 

--- a/src/main/java/TeamRhymix/Rhymix/controller/spotify/SpotifyController.java
+++ b/src/main/java/TeamRhymix/Rhymix/controller/spotify/SpotifyController.java
@@ -1,11 +1,13 @@
 package TeamRhymix.Rhymix.controller.spotify;
 
+import TeamRhymix.Rhymix.dto.SpotifyTrackDto;
 import TeamRhymix.Rhymix.service.SpotifyAuthService;
+import TeamRhymix.Rhymix.service.SpotifySearchService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -13,10 +15,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class SpotifyController {
 
     private final SpotifyAuthService spotifyAuthService;
+    private final SpotifySearchService spotifySearchService;
 
     @GetMapping("/token")
     public ResponseEntity<String> getToken() {
         String token = spotifyAuthService.getAccessToken();
         return ResponseEntity.ok(token);
+    }
+
+
+    @GetMapping("/search")
+    public ResponseEntity<List<SpotifyTrackDto>> searchTracks(@RequestParam String query) {
+        List<SpotifyTrackDto> results = spotifySearchService.searchTracks(query);
+        return ResponseEntity.ok(results);
     }
 }

--- a/src/main/java/TeamRhymix/Rhymix/domain/User.java
+++ b/src/main/java/TeamRhymix/Rhymix/domain/User.java
@@ -4,6 +4,7 @@ import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -15,7 +16,10 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Document(collection = "users")
-public class User {
+public class User implements Serializable {
+
+    private static final long serialVersionUID = 1L; //기본값으로 설정 -> 세션 직렬화 시 사용
+
     @Id
     private String id; // MongoDB 고유 식별자
     private String username; // 사용자 이름 (예: 홍길동)

--- a/src/main/java/TeamRhymix/Rhymix/dto/PostDto.java
+++ b/src/main/java/TeamRhymix/Rhymix/dto/PostDto.java
@@ -10,10 +10,16 @@ import java.util.List;
 @Setter
 public class PostDto {
     private String id;
-    private String userId;         // 유저 아이디 (사용자와 연결)
+    private String userId;
     private String trackId;
-    private String weather;        // 날씨
-    private String mood;           // 기분
-    private String comment;        // 코멘트
-    private List<Chat> chats;      // 댓글 목록
+    private String trackTitle;
+    private String trackArtist;
+    private String album;
+    private String coverImage;
+    private int duration;
+
+    private String weather;
+    private String mood;
+    private String comment;
+    private List<Chat> chats;
 }

--- a/src/main/java/TeamRhymix/Rhymix/dto/PostResponseDto.java
+++ b/src/main/java/TeamRhymix/Rhymix/dto/PostResponseDto.java
@@ -6,10 +6,13 @@ import lombok.Getter;
 @Getter
 @Builder
 public class PostResponseDto {
-    //추천글 등록 후 프론트로 넘길 응답 DTO
     private String postId;
     private String trackTitle;
     private String trackArtist;
+    private String album;
+    private String coverImage;
+    private int duration;
+
     private String mood;
     private String weather;
     private String comment;

--- a/src/main/java/TeamRhymix/Rhymix/mapper/PostMapper.java
+++ b/src/main/java/TeamRhymix/Rhymix/mapper/PostMapper.java
@@ -2,6 +2,7 @@ package TeamRhymix.Rhymix.mapper;
 
 import TeamRhymix.Rhymix.domain.Post;
 import TeamRhymix.Rhymix.dto.PostDto;
+import TeamRhymix.Rhymix.repository.TrackRepository;
 import TeamRhymix.Rhymix.service.TrackService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -12,31 +13,28 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class PostMapper {
 
-    private final TrackService trackService; // trackId 기반 조회용
+    private final TrackRepository trackRepository;
 
     public PostDto toDto(Post post) {
         PostDto dto = new PostDto();
+
         dto.setId(post.getId());
         dto.setUserId(post.getUserId());
-        dto.setTrackId(post.getTrackId());  // trackId만 설정
-        dto.setMood(post.getMood());
+        dto.setTrackId(post.getTrackId());
         dto.setWeather(post.getWeather());
+        dto.setMood(post.getMood());
         dto.setComment(post.getComment());
         dto.setChats(post.getChats());
+
+        // 트랙 정보 추가
+        trackRepository.findByTrackId(post.getTrackId()).ifPresent(track -> {
+            dto.setTrackTitle(track.getTitle());
+            dto.setTrackArtist(track.getArtist());
+            dto.setAlbum(track.getAlbum());
+            dto.setCoverImage(track.getCoverImage());
+            dto.setDuration(track.getDuration());
+        });
+
         return dto;
     }
-
-    public Post toEntity(PostDto dto) {
-        Post post = new Post();
-        post.setId(dto.getId());
-        post.setUserId(dto.getUserId());
-        post.setTrackId(dto.getTrackId());  // trackId만 저장
-        post.setMood(dto.getMood());
-        post.setWeather(dto.getWeather());
-        post.setComment(dto.getComment());
-        post.setChats(dto.getChats());
-        post.setCreatedAt(LocalDateTime.now());
-        return post;
-    }
-
 }

--- a/src/main/java/TeamRhymix/Rhymix/security/CustomUserDetailsService.java
+++ b/src/main/java/TeamRhymix/Rhymix/security/CustomUserDetailsService.java
@@ -17,11 +17,8 @@ public class CustomUserDetailsService implements UserDetailsService {
         User user = userRepository.findByNickname(nickname)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + nickname));
 
-        return org.springframework.security.core.userdetails.User.builder()
-                .username(user.getNickname())
-                .password(user.getPassword())
-                .roles("USER")
-                .build();
+        return new CustomUserDetails(user);
+
     }
 }
 

--- a/src/main/java/TeamRhymix/Rhymix/service/SpotifySearchService.java
+++ b/src/main/java/TeamRhymix/Rhymix/service/SpotifySearchService.java
@@ -2,6 +2,9 @@ package TeamRhymix.Rhymix.service;
 
 import TeamRhymix.Rhymix.dto.SpotifyTrackDto;
 
+import java.util.List;
+
 public interface SpotifySearchService {
     SpotifyTrackDto getTrackDetail(String trackId);
+    List<SpotifyTrackDto> searchTracks(String query);
 }

--- a/src/main/java/TeamRhymix/Rhymix/service/impl/SpotifySearchServiceImpl.java
+++ b/src/main/java/TeamRhymix/Rhymix/service/impl/SpotifySearchServiceImpl.java
@@ -4,10 +4,14 @@ import TeamRhymix.Rhymix.dto.SpotifyTrackDto;
 import TeamRhymix.Rhymix.service.SpotifyAuthService;
 import TeamRhymix.Rhymix.service.SpotifySearchService;
 import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -38,5 +42,41 @@ public class SpotifySearchServiceImpl implements SpotifySearchService {
                 .duration(json.getInt("duration_ms") / 1000)
                 .build();
     }
+
+    @Override
+    public List<SpotifyTrackDto> searchTracks(String query) {
+        String accessToken = spotifyAuthService.getAccessToken();
+        String url = "https://api.spotify.com/v1/search?q=" + query + "&type=track&limit=10";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        RestTemplate restTemplate = new RestTemplate();
+
+        ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+        JSONObject json = new JSONObject(response.getBody());
+        JSONArray items = json.getJSONObject("tracks").getJSONArray("items");
+
+        List<SpotifyTrackDto> result = new ArrayList<>();
+
+        for (int i = 0; i < items.length(); i++) {
+            JSONObject item = items.getJSONObject(i);
+
+            SpotifyTrackDto dto = SpotifyTrackDto.builder()
+                    .trackId(item.getString("id"))
+                    .title(item.getString("name"))
+                    .artist(item.getJSONArray("artists").getJSONObject(0).getString("name"))
+                    .album(item.getJSONObject("album").getString("name"))
+                    .albumImageUrl(item.getJSONObject("album").getJSONArray("images").getJSONObject(0).getString("url"))
+                    .duration(item.getInt("duration_ms") / 1000)
+                    .build();
+
+            result.add(dto);
+        }
+
+        return result;
+    }
+
 }
 

--- a/src/main/java/TeamRhymix/Rhymix/service/impl/TrackServiceImpl.java
+++ b/src/main/java/TeamRhymix/Rhymix/service/impl/TrackServiceImpl.java
@@ -24,9 +24,9 @@ public class TrackServiceImpl implements TrackService {
                             .trackId(dto.getTrackId())
                             .title(dto.getTitle())
                             .artist(dto.getArtist())
-                            .album("Unknown")
+                            .album(dto.getAlbum()) // <- 실제 앨범명
                             .coverImage(dto.getAlbumImageUrl())
-                            .duration(180)
+                            .duration(dto.getDuration()) // <- ms → s 변환 완료 상태
                             .build();
                     return trackRepository.save(newTrack);
                 });
@@ -34,8 +34,13 @@ public class TrackServiceImpl implements TrackService {
 
     @Override
     public Track findByTrackId(String trackId) {
+        if (trackId == null || trackId.isBlank()) {
+            throw new IllegalArgumentException("trackId는 null일 수 없습니다.");
+        }
+
         return trackRepository.findByTrackId(trackId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 trackId에 대한 Track 정보가 없습니다: " + trackId));
     }
+
 
 }

--- a/src/main/resources/static/js/today.js
+++ b/src/main/resources/static/js/today.js
@@ -27,10 +27,11 @@ document.getElementById("spotifySearchBtn").addEventListener("click", async () =
             <strong>${track.title}</strong> - ${track.artist}
             <img src="${track.albumImageUrl}" width="40" style="vertical-align:middle;">
             <button class="select-track-btn" 
-              data-id="${track.trackId}" 
+              data-track-id="${track.trackId}"
               data-title="${track.title}" 
               data-artist="${track.artist}" 
               data-cover="${track.albumImageUrl}">선택</button>
+
           </div>
         `;
             resultList.appendChild(li);
@@ -40,7 +41,9 @@ document.getElementById("spotifySearchBtn").addEventListener("click", async () =
         document.querySelectorAll(".select-track-btn").forEach(btn => {
             btn.addEventListener("click", (e) => {
                 const t = e.target.dataset;
-                selectedTrackId = t.id;
+                console.log("🎯 선택된 트랙 정보:", t);         // ✅ 콘솔로 확인
+                console.log("✅ trackId:", t.trackId);         // 반드시 찍혀야 함
+                selectedTrackId = t.trackId;
 
                 document.getElementById("trackTitle").textContent = t.title;
                 document.getElementById("trackArtist").textContent = t.artist;
@@ -59,13 +62,6 @@ document.getElementById("spotifySearchBtn").addEventListener("click", async () =
 // 저장 버튼 클릭
 document.getElementById("saveBtn").addEventListener("click", async () => {
     try {
-        const token = localStorage.getItem("accessToken");
-        if (!token) {
-            alert("로그인이 필요합니다.");
-            window.location.href = "/login";
-            return;
-        }
-
         if (!selectedTrackId) {
             alert("🎵 먼저 곡을 검색하고 선택해주세요.");
             return;
@@ -85,19 +81,21 @@ document.getElementById("saveBtn").addEventListener("click", async () => {
             comment: comment
         };
 
-        // 저장 요청
         const response = await fetch("/api/posts", {
             method: "POST",
             headers: {
-                "Content-Type": "application/json",
-                "Authorization": `Bearer ${token}`  //JWT 포함
+                "Content-Type": "application/json"
             },
-            body: JSON.stringify(postData)
+            body: JSON.stringify(postData),
+            credentials: "include"
         });
 
         if (response.ok) {
             alert("오늘의 추천곡이 등록되었습니다!");
             window.location.href = "/main";
+        } else if (response.status === 401) {
+            alert("로그인이 필요합니다.");
+            window.location.href = "/login";
         } else {
             alert("저장에 실패했습니다.");
         }

--- a/src/main/resources/static/js/today.js
+++ b/src/main/resources/static/js/today.js
@@ -41,8 +41,8 @@ document.getElementById("spotifySearchBtn").addEventListener("click", async () =
         document.querySelectorAll(".select-track-btn").forEach(btn => {
             btn.addEventListener("click", (e) => {
                 const t = e.target.dataset;
-                console.log("🎯 선택된 트랙 정보:", t);         // ✅ 콘솔로 확인
-                console.log("✅ trackId:", t.trackId);         // 반드시 찍혀야 함
+                console.log("선택된 트랙 정보:", t);
+                console.log("trackId:", t.trackId);
                 selectedTrackId = t.trackId;
 
                 document.getElementById("trackTitle").textContent = t.title;
@@ -67,6 +67,21 @@ document.getElementById("saveBtn").addEventListener("click", async () => {
             return;
         }
 
+        // 1. 이미 오늘 곡이 등록되었는지 확인
+        const todayResponse = await fetch("/api/posts/today", {
+            method: "GET",
+            credentials: "include"
+        });
+
+        if (todayResponse.ok) {
+            // 2. 이미 추천곡이 존재함 >> 사용자에게 수정 여부 확인
+            const confirmUpdate = confirm("오늘 이미 추천곡을 등록하셨습니다.\n새로운 곡으로 수정하시겠습니까?");
+            if (!confirmUpdate) {
+                return; // 사용자 취소 선택
+            }
+        }
+
+        // 3. 계속 진행
         const moodSelect = document.getElementById("mood");
         const weatherSelect = document.getElementById("weather");
         const comment = document.getElementById("comment").value;

--- a/src/main/resources/static/js/today.js
+++ b/src/main/resources/static/js/today.js
@@ -1,4 +1,4 @@
-let selectedTrackId = null;  // ✅ 선택된 Spotify 트랙 ID 저장용
+let selectedTrackId = null;  //선택된 Spotify 트랙 ID 저장 위함
 
 // 모달 열기
 document.getElementById("openModalBtn").addEventListener("click", () => {
@@ -10,7 +10,7 @@ document.getElementById("cancelTrackBtn").addEventListener("click", () => {
     document.getElementById("manualInputModal").style.display = "none";
 });
 
-// Spotify 검색 버튼 클릭
+//곡검색 버튼
 document.getElementById("spotifySearchBtn").addEventListener("click", async () => {
     const query = document.getElementById("spotifySearchInput").value;
     const resultList = document.getElementById("spotifySearchResults");
@@ -59,14 +59,12 @@ document.getElementById("spotifySearchBtn").addEventListener("click", async () =
 // 저장 버튼 클릭
 document.getElementById("saveBtn").addEventListener("click", async () => {
     try {
-        const userRes = await fetch("/api/auth/me");
-        if (!userRes.ok) {
+        const token = localStorage.getItem("accessToken");
+        if (!token) {
             alert("로그인이 필요합니다.");
+            window.location.href = "/login";
             return;
         }
-
-        const user = await userRes.json();
-        const userId = user.nickname;
 
         if (!selectedTrackId) {
             alert("🎵 먼저 곡을 검색하고 선택해주세요.");
@@ -81,24 +79,19 @@ document.getElementById("saveBtn").addEventListener("click", async () => {
         const weather = weatherSelect.options[weatherSelect.selectedIndex].text;
 
         const postData = {
-            userId: userId,
             trackId: selectedTrackId,
             mood: mood,
             weather: weather,
             comment: comment
         };
 
-        // 이미 오늘 등록한 추천곡이 있는지 확인
-        const checkRes = await fetch(`/api/posts/today?userId=${userId}`);
-        if (checkRes.ok) {
-            const confirmUpdate = confirm("오늘의 추천곡이 이미 등록되어 있습니다. 수정하시겠습니까?");
-            if (!confirmUpdate) return;
-        }
-
         // 저장 요청
         const response = await fetch("/api/posts", {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${token}`  //JWT 포함
+            },
             body: JSON.stringify(postData)
         });
 


### PR DESCRIPTION
1. 오늘의 추천곡 등록 스포티파이 api로 검색 후 메타데이터 불러오도록 수정 완료
  - 기존 : 사용자 수동 입력
  - 변경 후 : 검색하여 곡 정보 불러올 수 있음

2. GET /api/posts/today 요청에 인증 세션 누락 문제 해결
  - fetch 요청에 credentials: "include" 추가하여 세션 기반 인증 정상화
  - 오늘 추천곡 중복 등록 시 사용자 확인 로직이 정상 동작하도록 수정