### PR TITLE
fix: GET /api/posts/today 요청에 인증 세션 누락 문제 해결

### DIFF
--- a/src/main/java/TeamRhymix/Rhymix/controller/post/PostController.java
+++ b/src/main/java/TeamRhymix/Rhymix/controller/post/PostController.java
@@ -15,6 +15,7 @@ import TeamRhymix.Rhymix.dto.PostResponseDto;
 
 import TeamRhymix.Rhymix.service.TrackService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,6 +25,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/posts")
 @RequiredArgsConstructor
@@ -43,10 +45,12 @@ public class PostController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         if (userDetails == null) {
+            log.warn("[POST] 인증 실패 - userDetails is null");
             return ResponseEntity.status(401).build();
         }
 
         String userId = userDetails.getUsername();
+        log.debug("[POST] 인증된 사용자 ID: {}", userId);
 
         // 트랙 먼저 저장
         Track track = trackService.findOrSaveTrack(request.getTrackId());

--- a/src/main/java/TeamRhymix/Rhymix/security/CustomUserDetailsService.java
+++ b/src/main/java/TeamRhymix/Rhymix/security/CustomUserDetailsService.java
@@ -17,11 +17,8 @@ public class CustomUserDetailsService implements UserDetailsService {
         User user = userRepository.findByNickname(nickname)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + nickname));
 
-        return org.springframework.security.core.userdetails.User.builder()
-                .username(user.getNickname())
-                .password(user.getPassword())
-                .roles("USER")
-                .build();
+        return new CustomUserDetails(user);
+
     }
 }
 

--- a/src/main/resources/static/js/today.js
+++ b/src/main/resources/static/js/today.js
@@ -41,8 +41,8 @@ document.getElementById("spotifySearchBtn").addEventListener("click", async () =
         document.querySelectorAll(".select-track-btn").forEach(btn => {
             btn.addEventListener("click", (e) => {
                 const t = e.target.dataset;
-                console.log("🎯 선택된 트랙 정보:", t);         // ✅ 콘솔로 확인
-                console.log("✅ trackId:", t.trackId);         // 반드시 찍혀야 함
+                console.log("선택된 트랙 정보:", t);
+                console.log("trackId:", t.trackId);
                 selectedTrackId = t.trackId;
 
                 document.getElementById("trackTitle").textContent = t.title;
@@ -67,6 +67,21 @@ document.getElementById("saveBtn").addEventListener("click", async () => {
             return;
         }
 
+        // 1. 이미 오늘 곡이 등록되었는지 확인
+        const todayResponse = await fetch("/api/posts/today", {
+            method: "GET",
+            credentials: "include"
+        });
+
+        if (todayResponse.ok) {
+            // 2. 이미 추천곡이 존재함 >> 사용자에게 수정 여부 확인
+            const confirmUpdate = confirm("오늘 이미 추천곡을 등록하셨습니다.\n새로운 곡으로 수정하시겠습니까?");
+            if (!confirmUpdate) {
+                return; // 사용자 취소 선택
+            }
+        }
+
+        // 3. 계속 진행
         const moodSelect = document.getElementById("mood");
         const weatherSelect = document.getElementById("weather");
         const comment = document.getElementById("comment").value;


### PR DESCRIPTION
1. 오늘의 추천곡 등록 스포티파이 api로 검색 후 메타데이터 불러오도록 수정 완료
  - 기존 : 사용자 수동 입력
  - 변경 후 : 검색하여 곡 정보 불러올 수 있음
  - 
2. GET /api/posts/today 요청에 인증 세션 누락 문제 해결
  - fetch 요청에 credentials: "include" 추가하여 세션 기반 인증 정상화
  - 오늘 추천곡 중복 등록 시 사용자 확인 로직이 정상 동작하도록 수정