### PR TITLE
refactor: 메인페이지 추천곡/캘린더 모달 개선 및 플레이리스트 기능 리팩토링

### DIFF
--- a/src/main/java/TeamRhymix/Rhymix/controller/post/PostController.java
+++ b/src/main/java/TeamRhymix/Rhymix/controller/post/PostController.java
@@ -114,11 +114,12 @@ public class PostController {
 
     @GetMapping("/monthly")
     public ResponseEntity<List<PostDto>> getMonthlyPosts(
-            @AuthenticationPrincipal org.springframework.security.core.userdetails.User userDetails,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam int year,
             @RequestParam int month
     ) {
         if (userDetails == null) {
+            log.warn("[GET monthly] 인증 실패 - userDetails is null");
             return ResponseEntity.status(401).build();
         }
 

--- a/src/main/java/TeamRhymix/Rhymix/controller/post/PostController.java
+++ b/src/main/java/TeamRhymix/Rhymix/controller/post/PostController.java
@@ -77,14 +77,17 @@ public class PostController {
     @GetMapping("/today")
     public ResponseEntity<PostResponseDto> getTodayPost(
             @RequestParam(required = false) String nickname,
-            @AuthenticationPrincipal org.springframework.security.core.userdetails.User userDetails
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         if (nickname == null) {
             if (userDetails == null) {
+                log.warn("[GET] 인증 실패 - userDetails is null");
                 return ResponseEntity.status(401).build();
             }
             nickname = userDetails.getUsername();
         }
+
+        log.debug("[GET] 조회할 nickname: {}", nickname);
 
         Post post = postService.getTodayPost(nickname);
         if (post == null) return ResponseEntity.notFound().build();

--- a/src/main/java/TeamRhymix/Rhymix/domain/Playlist.java
+++ b/src/main/java/TeamRhymix/Rhymix/domain/Playlist.java
@@ -25,7 +25,7 @@ public class Playlist {
 
     private String type;
 
-    private List<String> trackIds; // Post ID 문자열 리스트
+    private List<String> postIds;
 
     private LocalDateTime createdAt;
 }

--- a/src/main/java/TeamRhymix/Rhymix/dto/PlaylistDto.java
+++ b/src/main/java/TeamRhymix/Rhymix/dto/PlaylistDto.java
@@ -1,6 +1,6 @@
 package TeamRhymix.Rhymix.dto;
 
-import TeamRhymix.Rhymix.domain.Post;
+import TeamRhymix.Rhymix.domain.Track;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +16,6 @@ public class PlaylistDto {
     private String id;
     private String title;
     private String type;
-    private List<Post> tracks;
+    List<PlaylistTrackInfo> tracks;
 }
 

--- a/src/main/java/TeamRhymix/Rhymix/dto/PlaylistTrackInfo.java
+++ b/src/main/java/TeamRhymix/Rhymix/dto/PlaylistTrackInfo.java
@@ -1,0 +1,9 @@
+package TeamRhymix.Rhymix.dto;
+
+public record PlaylistTrackInfo(
+        String title,
+        String artist,
+        String mood,
+        String weather
+) {}
+

--- a/src/main/java/TeamRhymix/Rhymix/service/PlaylistService.java
+++ b/src/main/java/TeamRhymix/Rhymix/service/PlaylistService.java
@@ -11,4 +11,6 @@ public interface PlaylistService {
     Playlist findLatestMonthlyPlaylistByNickname(String nickname);
 
     PlaylistDto generateThemePlaylist(String nickname, String tag);
+
+    PlaylistDto getThemePlaylistPreview(String nickname, String tag);
 }

--- a/src/main/java/TeamRhymix/Rhymix/service/impl/PlaylistServiceImpl.java
+++ b/src/main/java/TeamRhymix/Rhymix/service/impl/PlaylistServiceImpl.java
@@ -2,6 +2,7 @@ package TeamRhymix.Rhymix.service.impl;
 
 import TeamRhymix.Rhymix.domain.*;
 import TeamRhymix.Rhymix.dto.PlaylistDto;
+import TeamRhymix.Rhymix.dto.PlaylistTrackInfo;
 import TeamRhymix.Rhymix.exception.ErrorCode;
 import TeamRhymix.Rhymix.exception.PlaylistException;
 import TeamRhymix.Rhymix.service.PlaylistService;
@@ -17,6 +18,9 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -90,7 +94,7 @@ public class PlaylistServiceImpl implements PlaylistService {
                 .userId(user.getNickname())
                 .title(title)
                 .type("monthly")
-                .trackIds(trackIds)
+                .postIds(posts.stream().map(Post::getId).toList())
                 .createdAt(LocalDateTime.now())
                 .build();
 
@@ -104,35 +108,67 @@ public class PlaylistServiceImpl implements PlaylistService {
     public PlaylistDto getPlaylistWithTracks(String playlistId) {
         log.info("playlistId 요청됨: '{}'", playlistId);
 
-        // 유효성 검사
         if (playlistId == null || playlistId.trim().isEmpty()) {
             throw new PlaylistException(ErrorCode.INVALID_ID_FORMAT);
         }
 
-        ObjectId objectId;  // 문자열을 ObjectId로 변환
+        ObjectId objectId;
         try {
             objectId = new ObjectId(playlistId);
         } catch (IllegalArgumentException e) {
             throw new PlaylistException(ErrorCode.INVALID_ID_FORMAT);
         }
 
-        // 플레이리스트 조회
         Playlist playlist = mongoTemplate.findById(objectId, Playlist.class);
         if (playlist == null) {
             throw new PlaylistException(ErrorCode.PLAYLIST_NOT_FOUND);
         }
 
-        // 포함된 트랙(Post) 정보 조회
-        Query trackQuery = new Query(Criteria.where("_id").in(playlist.getTrackIds()));
-        List<Post> posts = mongoTemplate.find(trackQuery, Post.class);
+        List<String> postIds = playlist.getPostIds(); // 필드명 변경됨
 
-        return new PlaylistDto(   // DTO 형태로 반환
+        // 1. postId 목록으로 Post 조회
+        List<Post> posts = mongoTemplate.find(
+                Query.query(Criteria.where("_id").in(postIds)), Post.class
+        );
+
+        // 2. post에서 trackId 추출 후 Track 조회
+        List<String> trackIds = posts.stream()
+                .map(Post::getTrackId)
+                .distinct()
+                .toList();
+
+        List<Track> tracks = mongoTemplate.find(
+                Query.query(Criteria.where("trackId").in(trackIds)), Track.class
+        );
+
+        // 3. trackId → Track 매핑
+        Map<String, Track> trackMap = tracks.stream()
+                .collect(Collectors.toMap(Track::getTrackId, t -> t));
+
+        // 4. PlaylistTrackInfo 구성
+        List<PlaylistTrackInfo> trackInfoList = posts.stream()
+                .map(post -> {
+                    Track track = trackMap.get(post.getTrackId());
+                    if (track == null) return null;
+
+                    return new PlaylistTrackInfo(
+                            track.getTitle(),
+                            track.getArtist(),
+                            post.getMood(),
+                            post.getWeather()
+                    );
+                })
+                .filter(Objects::nonNull)
+                .toList();
+
+        return new PlaylistDto(
                 playlist.getId(),
                 playlist.getTitle(),
                 playlist.getType(),
-                posts
+                trackInfoList
         );
     }
+
 
     /**
      * 최신 월별 플레이리스트 조회
@@ -182,7 +218,7 @@ public class PlaylistServiceImpl implements PlaylistService {
         String title = tag + " 테마";
         String type = "theme";
 
-        // 기존 theme 플레이리스트 있으면 삭제 (한 사용자가 동일 태그로 하나만 유지)
+        // 기존 동일 테마 플레이리스트 삭제
         Query query = Query.query(
                 Criteria.where("userId").is(user.getNickname())
                         .and("type").is(type)
@@ -190,20 +226,52 @@ public class PlaylistServiceImpl implements PlaylistService {
         );
         mongoTemplate.remove(query, Playlist.class);
 
+        // trackId 추출
+        List<String> trackIds = posts.stream()
+                .map(Post::getTrackId)
+                .distinct()
+                .toList();
+
+        List<Track> tracks = mongoTemplate.find(
+                Query.query(Criteria.where("trackId").in(trackIds)),
+                Track.class
+        );
+
+        // trackId → Track 매핑
+        Map<String, Track> trackMap = tracks.stream()
+                .collect(Collectors.toMap(Track::getTrackId, t -> t));
+
+        // PlaylistTrackInfo 구성
+        List<PlaylistTrackInfo> trackInfos = posts.stream()
+                .map(post -> {
+                    Track track = trackMap.get(post.getTrackId());
+                    if (track == null) return null;
+
+                    return new PlaylistTrackInfo(
+                            track.getTitle(),
+                            track.getArtist(),
+                            post.getMood(),
+                            post.getWeather()
+                    );
+                })
+                .filter(Objects::nonNull)
+                .toList();
+
+        // Playlist 저장 (postIds 저장)
         Playlist playlist = Playlist.builder()
                 .userId(user.getNickname())
                 .title(title)
                 .type(type)
-                .trackIds(posts.stream().map(Post::getId).toList())
+                .postIds(posts.stream().map(Post::getId).toList())
                 .createdAt(LocalDateTime.now())
                 .build();
 
         Playlist saved = mongoTemplate.save(playlist);
 
-        return new PlaylistDto(
-                saved.getId(), title, type, posts
-        );
+        return new PlaylistDto(saved.getId(), title, type, trackInfos);
     }
+
+
 
 }
 

--- a/src/main/java/TeamRhymix/Rhymix/service/impl/PlaylistServiceImpl.java
+++ b/src/main/java/TeamRhymix/Rhymix/service/impl/PlaylistServiceImpl.java
@@ -149,7 +149,10 @@ public class PlaylistServiceImpl implements PlaylistService {
         List<PlaylistTrackInfo> trackInfoList = posts.stream()
                 .map(post -> {
                     Track track = trackMap.get(post.getTrackId());
-                    if (track == null) return null;
+                    if (track == null) {
+                        log.warn("트랙 정보가 존재하지 않습니다. trackId: {}", post.getTrackId());
+                        return null;
+                    }
 
                     return new PlaylistTrackInfo(
                             track.getTitle(),

--- a/src/main/java/TeamRhymix/Rhymix/service/impl/PostServiceImpl.java
+++ b/src/main/java/TeamRhymix/Rhymix/service/impl/PostServiceImpl.java
@@ -29,30 +29,33 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public Post savePost(PostRequestDto requestDto, String userId) {
-        // 오늘 날짜 기준 기존 포스트 존재 여부 확인
         LocalDateTime start = LocalDate.now().atStartOfDay();
         LocalDateTime end = start.plusDays(1).minusSeconds(1);
+
         Post existing = postRepository.findTodayPostByUserId(userId, start, end);
 
         if (existing != null) {
+            // 기존 포스트 업데이트
             existing.setMood(requestDto.getMood());
             existing.setWeather(requestDto.getWeather());
             existing.setComment(requestDto.getComment());
-            existing.setCreatedAt(LocalDateTime.now());
             existing.setTrackId(requestDto.getTrackId());
+            existing.setCreatedAt(LocalDateTime.now());
             return postRepository.save(existing);
-        } else {
-            Post newPost = Post.builder()
-                    .userId(userId)
-                    .mood(requestDto.getMood())
-                    .weather(requestDto.getWeather())
-                    .comment(requestDto.getComment())
-                    .trackId(requestDto.getTrackId())
-                    .createdAt(LocalDateTime.now())
-                    .build();
-            return postRepository.save(newPost);
         }
+
+        Post newPost = Post.builder()
+                .userId(userId)
+                .mood(requestDto.getMood())
+                .weather(requestDto.getWeather())
+                .comment(requestDto.getComment())
+                .trackId(requestDto.getTrackId())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        return postRepository.save(newPost);
     }
+
 
 
     @Override

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -79,23 +79,26 @@ function loadUserProfile() {
 
 // 오늘의 음악
 function loadTodayMusicAndComments(nickname) {
-    fetch('/api/posts/today')
+    fetch('/api/posts/today', {
+        method: 'GET',
+        credentials: 'include'
+    })
         .then(res => {
             if (!res.ok) throw new Error("추천곡 없음");
             return res.json();
         })
         .then(post => {
             const musicCard = document.querySelector('.music-card');
-            document.querySelector('.music-card img').src = post.cover || '/image/placeholder_album.png';
-            document.querySelector('.music-title-box').textContent = `🎵 ${post.title}`;
-            document.querySelector('.music-artist-box').textContent = `🎤 ${post.artist}`;
+            document.querySelector('.music-card img').src = post.coverImage || '/image/placeholder_album.png';
+            document.querySelector('.music-title-box').textContent = `🎵 ${post.trackTitle}`;
+            document.querySelector('.music-artist-box').textContent = `🎤 ${post.trackArtist}`;
             document.getElementById('weather-btn').textContent = post.weather || '';
             document.getElementById('mood-btn').textContent = post.mood || '';
             document.getElementById('music-comment').textContent = post.comment || '';
             musicCard.style.display = "block";
 
-            loadComments(post.id);
-            setupCommentSubmit(post.id, nickname);
+            loadComments(post.postId);
+            setupCommentSubmit(post.postId, nickname);
         })
         .catch(() => {
             const musicCard = document.querySelector('.music-card');
@@ -221,12 +224,12 @@ function setupCalendar(userId) {
                 if (!res.ok) return alert("추천곡을 불러올 수 없습니다.");
                 const data = await res.json();
 
-                document.getElementById("modalDetailTitle").textContent = data.title;
-                document.getElementById("modalDetailArtist").textContent = data.artist;
+                document.getElementById("modalDetailTitle").textContent = data.trackTitle;
+                document.getElementById("modalDetailArtist").textContent = data.trackArtist;
                 document.getElementById("modalDetailMood").textContent = data.mood || "-";
                 document.getElementById("modalDetailWeather").textContent = data.weather || "-";
                 document.getElementById("modalDetailComment").textContent = data.comment || "-";
-                document.getElementById("modalDetailCover").src = data.cover || "/image/default-cover.png";
+                document.getElementById("modalDetailCover").src = data.coverImage || "/image/default-cover.png";
 
                 document.getElementById("trackDetailModal").style.display = "flex";
             } catch (e) {


### PR DESCRIPTION
### 개요
메인 페이지에서 오늘의 추천곡, 캘린더 모달, 월별/테마 플레이리스트 관련 기능 개선 및 리팩토링을 반영한 PR입니다.

### 주요 변경 사항
#### 오늘의 추천곡
- 곡 정보 출력 시 Post와 Track을 분리하여 Track 정보는 별도로 조회하여 출력

#### 캘린더 모달
- 모달 내 곡 정보에 mood, weather, 코멘트, track 정보가 함께 표시됨

#### 월별 플레이리스트
- 월별 플레이리스트 생성 시 Post 기준으로 Track 정보를 조회하여 PlaylistTrackInfo로 구성
- 기존 방식에서 track 리스트 응답이 아닌 post 기반 track 응답으로 변경
- 생성 조건: 해당 월에 작성된 Post가 1개 이상 존재할 경우에만 생성
- 이미 생성된 경우 중복 생성 방지 (title, type, userId 조합으로 중복 체크)

#### 테마 플레이리스트 
- mood, weather 태그 기반으로 사용자 Post 목록 조회 후 PlaylistTrackInfo 응답
- 기존에 같은 테마 이름의 플레이리스트가 있으면 삭제 후 새로 저장
- 저장된 테마 플레이리스트 또는 임시 응답(조회 전용) 구조 동일하게 통일

#### 기타
- PlaylistDto 리팩토링: Track과 Post를 함께 조합한 PlaylistTrackInfo 구조 적용
- Controller, Service 계층 분리 및 예외 처리 일관화

### 테스트 시나리오
 1. 오늘의 추천곡 미등록 상태에서 메시지 출력 확인
 2. 캘린더 날짜 선택 시 모달 정상 출력
 3. 월별 플레이리스트 생성 및 재요청 시 중복 생성 방지
 4. 테마 선택 시 해당 테마에 맞는 곡 목록 출력
 5. Track이 삭제된 경우에도 NullPointer 방지