### PR TITLE
월별 플레이리스트에서 앨범 커버 이미지가 표시되지 않는 문제 해결

### DIFF
--- a/src/main/java/TeamRhymix/Rhymix/domain/playlist/dto/PlaylistTrackInfo.java
+++ b/src/main/java/TeamRhymix/Rhymix/domain/playlist/dto/PlaylistTrackInfo.java
@@ -4,6 +4,7 @@ public record PlaylistTrackInfo(
         String title,
         String artist,
         String mood,
-        String weather
+        String weather,
+        String coverImage
 ) {}
 

--- a/src/main/java/TeamRhymix/Rhymix/domain/playlist/service/PlaylistServiceImpl.java
+++ b/src/main/java/TeamRhymix/Rhymix/domain/playlist/service/PlaylistServiceImpl.java
@@ -160,7 +160,8 @@ public class PlaylistServiceImpl implements PlaylistService {
                             track.getTitle(),
                             track.getArtist(),
                             post.getMood(),
-                            post.getWeather()
+                            post.getWeather(),
+                            track.getCoverImage()
                     );
                 })
                 .filter(Objects::nonNull)
@@ -256,7 +257,8 @@ public class PlaylistServiceImpl implements PlaylistService {
                             track.getTitle(),
                             track.getArtist(),
                             post.getMood(),
-                            post.getWeather()
+                            post.getWeather(),
+                            track.getCoverImage()
                     );
                 })
                 .filter(Objects::nonNull)
@@ -312,7 +314,8 @@ public class PlaylistServiceImpl implements PlaylistService {
                             track.getTitle(),
                             track.getArtist(),
                             post.getMood(),
-                            post.getWeather()
+                            post.getWeather(),
+                            track.getCoverImage()
                     );
                 })
                 .filter(Objects::nonNull)

--- a/src/main/resources/static/js/monthly.js
+++ b/src/main/resources/static/js/monthly.js
@@ -60,7 +60,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     const showTrack = (track) => {
         titleEl.textContent = track.title;
         artistEl.textContent = track.artist;
-        coverEl.src = track.cover;
+        coverEl.src = track.coverImage;
     };
 
     showTrack(posts[0]);


### PR DESCRIPTION
🛠️ 수정 내용
-`PlaylistTrackInfo` DTO에 `coverImage` 필드를 새로 추가 -> 트랙 정보에 앨범 커버 URL도 포함되도록 개선
- 서비스 단에서 Post → Track을 통해 트랙 상세 정보를 조회할 때, 커버 이미지 정보도 함께 응답에 포함되도록 수정
- 월별 플레이리스트 화면에서 상단 대표 곡의 앨범 커버 이미지가 로드되지 않던 문제 해결
- track.cover로 접근하던 기존 JS 코드를 track.coverImage로 수정하여 실제 응답 필드 이름과 일치