### PR TITLE
기분/날씨 테마 선택 시 모달 제목 오류 수정 및 '테마' 명칭 개선

### DIFF
--- a/src/main/java/TeamRhymix/Rhymix/domain/playlist/service/PlaylistServiceImpl.java
+++ b/src/main/java/TeamRhymix/Rhymix/domain/playlist/service/PlaylistServiceImpl.java
@@ -221,7 +221,7 @@ public class PlaylistServiceImpl implements PlaylistService {
             throw new PlaylistException(ErrorCode.NO_POSTS);
         }
 
-        String title = tag + " 테마";
+        String title = tag + " 플레이리스트";
         String type = "theme";
 
         // 기존 동일 테마 플레이리스트 삭제

--- a/src/main/resources/static/js/playlist.js
+++ b/src/main/resources/static/js/playlist.js
@@ -20,18 +20,16 @@ document.addEventListener("DOMContentLoaded", () => {
         const listEl = document.getElementById("theme-track-list");
         const iconEl = document.getElementById("theme-modal-icon");
 
-        const firstTrack = playlist.tracks[0];
-        const fullTag = firstTrack?.weather || firstTrack?.mood || "🎵"; // 예: "☀ 맑음"
-        const emoji = fullTag.split(" ")[0];
-        const label = fullTag.split(" ")[1];
+        const titleText = playlist.title || "테마 Playlist"; // ex) "😊 행복 테마"
+        const emoji = titleText.split(" ")[0]; // 이모지 추출
+        const label = titleText.substring(2);  // 이모지 이후 텍스트만
 
         iconEl.textContent = emoji;
-        titleEl.textContent = `${label} Playlist`;
+        titleEl.textContent = `${label}`; // label에 이미 "행복 테마" 포함됨
 
         listEl.innerHTML = playlist.tracks.map(t => `${t.title} - ${t.artist}`).join("<br>");
         modal.style.display = "flex";
     }
-
 
 
 


### PR DESCRIPTION
### 문제 
- 사용자가 기분/날씨 테마(예: 😊 행복, ⚡ 에너지 충전 등)를 선택해도, 모달 상단 제목이 항상 '☀ 맑음 플레이리스트'로 출력되는 문제 
- JS에서 playlist.tracks[0].weather 값만을 기준으로 제목을 생성하고 있었음

### 해결 
- 백엔드에서 `playlist.title` 값을 `~ 플레이리스트` 형식으로 명시하여 응답하도록 수정
  - 기존: `😊 행복 테마` → 변경: `😊 행복 플레이리스트`
- 프론트엔드에서는 `playlist.title` 값을 그대로 사용하여 모달 제목을 구성하도록 하여 정확한 테마명이 표시되도록 수정 완료

### 주요 변경점
- `PlaylistServiceImpl.generateThemePlaylist()` 및 `getThemePlaylistPreview()`:
  - 기존 `"~ 테마"` → `"~ 플레이리스트"`로 `title` 값 생성 방식 변경
- 모달 상단에 출력되는 제목이 선택한 테마(기분/날씨)에 맞게 정확히 출력됨
- 추가로 사용자 관점에서 더 직관적인 용어인 `"플레이리스트"`를 사용하도록 개선

